### PR TITLE
😄🎹 added /docs/gettingstarted endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ See the detault index.html view — it's the default page that you see when you 
 page! It steps you through setting up the .env file, customizing the pages, using the embed,
 and a few other helpful tips.
 
+The getting started guide is also available at the 
+[/docs/gettingstarted](https://substation.glitch.me/docs/gettingstarted) route in your 
+Substation DIY app.
+
 Collaborating on Glitch
 -----------------------
 Glitch, while based on git, is different from a traditional git development environment. The

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -22,29 +22,29 @@ module.exports = function (app, db) {
   // The main page. Will show user customized pages if present at
   // /config/views/index.html and if not it will render the default
   // page found at /views/index.html
-  app.get("/", function(request, response) {
-      request.details = {
-        substationURL: process.env.URL,
-        copy: {
-          title: process.env.TITLE
-        }
-      };
-    
-      var file = __dirname + '/../config/views/index.html';
-      
-      // we're looking for the /config/views/index.html file — if 
-      // it's present we use that as our main view, if not we fall
-      // back to the default index.html in the /views folder
-      try {
-        if (fs.existsSync(file)) {
-          response.render(file, request.details);    
-        } else {
-          response.render("index", request.details);    
-        }
-      } catch(err) {
-        console.error(err);
-        response.render("index", request.details);    
+  app.get(["/","/docs/gettingstarted"], function(request, response) {
+    request.details = {
+      substationURL: process.env.URL,
+      copy: {
+        title: process.env.TITLE
       }
+    };
+
+    var file = __dirname + '/../config/views/index.html';
+
+    // we're looking for the /config/views/index.html file — if 
+    // it's present we use that as our main view, if not we fall
+    // back to the default index.html in the /views folder
+    try {
+      if (fs.existsSync(file) && request.originalUrl == '/') {
+        response.render(file, request.details);    
+      } else {
+        response.render("docs/gettingstarted", request.details);    
+      }
+    } catch(err) {
+      console.error(err);
+      response.render("docs/gettingstarted", request.details);    
+    }
   });
   
   /****** ROUTE: /customcss *****************************************/

--- a/views/docs/gettingstarted.html
+++ b/views/docs/gettingstarted.html
@@ -20,7 +20,6 @@
   <link rel="stylesheet" type="text/css" href="/skeleton.css">
   <link rel="stylesheet" type="text/css" href="/custom.css">
   <link rel="stylesheet" type="text/css" href="/overlay.css">
-  <link rel="stylesheet" type="text/css" href="/customcss">
 
   <!-- Favicon
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
The new route is still served as the default "/" page until that's been customized, but giving it a permanent home means it's always available to be accessed. 